### PR TITLE
fix(Makefile): fix cflags ignoring problem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,8 @@ SRC+=src/rbtree.c
 
 OBJ=$(SRC:.c=.o)
 
-src/%.o: %.c
-	$(CC) -c $< $(CFLAG)
-
+src/%.o: src/%.c
+	$(CC) -c $< $(CFLAG) -o $@
 
 all: static
 	cat src/context.h > coroutine.h


### PR DESCRIPTION
Since `CFLAGS` have been ignored in `Makefile`, this patch used implict variable[1] to add it back.
Also removed `src/%.o` part due to implict rules.

The result of `make` before this patch is:
```
cc    -c -o src/runqueue.o src/runqueue.c
cc    -c -o src/sched.o src/sched.c
cc    -c -o src/coroutine.o src/coroutine.c
cc    -c -o src/rbtree.o src/rbtree.c
ar crsv coroutine.a src/runqueue.o src/sched.o src/coroutine.o src/rbtree.o
a - src/runqueue.o
a - src/sched.o
a - src/coroutine.o
a - src/rbtree.o
cat src/context.h > coroutine.h
cat src/coroutine.h >> coroutine.h
rm -f src/*.o
```

And the correct result should be:
```
cc -g -Wall -O1   -c -o src/runqueue.o src/runqueue.c
cc -g -Wall -O1   -c -o src/sched.o src/sched.c
In file included from src/sched.c:8:
src/sched.c:63:33: warning: ‘rb_cmp_search’ defined but not used [-Wunused-function]
   63 | static RBTREE_CMP_SEARCH_DEFINE(rb_cmp_search, _n1, key)
      |                                 ^~~~~~~~~~~~~
src/rbtree.h:175:9: note: in definition of macro ‘RBTREE_CMP_SEARCH_DEFINE’
  175 |     int name(struct rb_node *rbnode, void *key)
      |         ^~~~
cc -g -Wall -O1   -c -o src/coroutine.o src/coroutine.c
src/coroutine.c: In function ‘__cr_to_proc’:
src/coroutine.c:123:16: warning: unused variable ‘cr’ [-Wunused-variable]
  123 |     struct cr *cr = task->cr;
      |                ^~
cc -g -Wall -O1   -c -o src/rbtree.o src/rbtree.c
ar crsv coroutine.a src/runqueue.o src/sched.o src/coroutine.o src/rbtree.o
a - src/runqueue.o
a - src/sched.o
a - src/coroutine.o
a - src/rbtree.o
cat src/context.h > coroutine.h
cat src/coroutine.h >> coroutine.h
rm -f src/*.o
```

So there were some problems need to be fixed in the future.

Make version: GNU Make 4.3

[1] https://www.gnu.org/software/make/manual/make.html#Implicit-Variables